### PR TITLE
Add pypng to requirements

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 httpx
 pymupdf
+pypng
 qrcode

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,8 @@ pymupdf==1.24.10
     # via -r requirements.in
 pymupdfb==1.24.10
     # via pymupdf
+pypng==0.20220715.0
+    # via -r requirements.in
 qrcode==8.0
     # via -r requirements.in
 sniffio==1.3.1


### PR DESCRIPTION
Since upgrading `qrcode` to 8.0, `pypng` is no longer automatically added to requirements. This change will manually add `pypng` to the project requirements.