### PR TITLE
Adjust font size on title page and export letter-size PDF

### DIFF
--- a/.github/workflows/gen-pdf.yaml
+++ b/.github/workflows/gen-pdf.yaml
@@ -41,4 +41,6 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         with:
           name: hymns.pdf
-          path: hymns.pdf
+          path: |
+            hymns.pdf
+            hymns-letter.pdf

--- a/hymns.py
+++ b/hymns.py
@@ -131,7 +131,8 @@ page = final.new_page(width=page_width, height=page_height)
 
 title_rect = (page_width * 0.1, page_height * 0.05, page_width * 0.9, page_height * 0.15)
 text = 'Hymns\x97For Home and Church'
-page.insert_textbox(title_rect, text, fontsize=30, fontname=font)
+# left aligned due to the extra wide \x97 char which messes up center algo
+page.insert_textbox(title_rect, text, fontsize=31, fontname=font)
 
 img_rect = (page_width * 0.1, page_width * 0.2, page_width * 0.9, (page_width * 0.9) + (page_width * 0.1))
 cover = pathlib.Path() / '.local/cache/cover.jpg'
@@ -144,7 +145,7 @@ page.insert_image(img_rect, filename=cover.resolve())
 
 link_rect = pymupdf.Rect(page_width * 0.1, page_height * 0.8, page_width * 0.9, page_height * 0.9)
 text = '\nScan this code to access these hymns digitally'
-page.insert_textbox(link_rect, text, fontsize=10, fontname=font, align=pymupdf.TEXT_ALIGN_CENTER)
+page.insert_textbox(link_rect, text, fontsize=12, fontname=font, align=pymupdf.TEXT_ALIGN_CENTER)
 page.insert_link({
     'kind': pymupdf.LINK_URI,
     'from': link_rect,

--- a/hymns.py
+++ b/hymns.py
@@ -121,8 +121,9 @@ def get_qr(text: str):
 
 
 font = 'times-roman'
-page_width = 495.0
-page_height = 711.0
+# This is the page size used by Church PDFs
+page_width = 495.0  #  6.875"
+page_height = 711.0  # 9.875"
 
 final = pymupdf.Document()
 
@@ -188,5 +189,16 @@ for hymn in hymn_data:
         final.new_page(width=page_width, height=page_height)
     doc.close()
 
+# resize to letter paper (sadly, this will drop the links)
+resized_doc = pymupdf.Document()
+
+letter = pymupdf.paper_size('letter')  # (612, 792) = 8.5"x11.0"
+for src_page in final:
+    dst_page = resized_doc.new_page(width=letter[0], height=letter[1])
+    if src_page.get_text():
+        dst_page.show_pdf_page(dst_page.rect, final, pno=src_page.number, keep_proportion=True)
+
+resized_doc.save('hymns-letter.pdf')
+resized_doc.close()
 final.save('hymns.pdf')
 final.close()


### PR DESCRIPTION
I increased the font size on the tile page: 
- I made the QR description size 12 instead of 10 to make it easier to read for people with decreased vision.
- I increased the title font from 30 to 31 because that made the text appear more centered over the image. I'm not sure if the font was substituted on my machine, however, because I'm on Linux. So, I can revert that change if it doesn't look better to you. 

I had issues getting Okular (my PDF viewer) to print the pages (I have a Brother color laser printer) in the center of the page when set to fill the page. So, I used mupdf to resize/center the page to letter so I could more easily print it.